### PR TITLE
DM-36174: Pin Python version in MyPy checks to 3.10.6.

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.10.6"
           cache: "pip"
 
       - name: Install


### PR DESCRIPTION
This works around https://github.com/python/mypy/issues/13627.