### PR TITLE
Also install tomli

### DIFF
--- a/.github/workflows/docstyle.yaml
+++ b/.github/workflows/docstyle.yaml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install
-        run: pip install pydocstyle
+        run: pip install pydocstyle tomli
 
       - name: Run docstyle
         run: pydocstyle  {{ inputs.args }}


### PR DESCRIPTION
Without this pydocstyle can't read pyproject.toml files. It turns out that all my actions are failing immediately with good status so the action think it passes.

> WARNING: The /home/runner/work/daf_butler/daf_butler/pyproject.toml configuration file was ignored, because the `tomli` package is not installed.