### PR TITLE
Enable github annotations from the flake8 output

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install
-        run: pip install flake8==4.0
+        run: pip install flake8==4.0 flake8-github-annotations
 
       - name: Run linter
-        run: flake8
+        run: flake8 --format github


### PR DESCRIPTION
This means that a failure in the linting will highlight the line causing the problem in the diff.