### PR TITLE
DM-43263: Allow specifying version of mypy

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -2,6 +2,12 @@ name: Run mypy
 
 on:
   workflow_call:
+    inputs:
+      mypy_package:
+        description: "The name and version number of the mypy package that will be passed to pip.  Example: mypy==1.9.0"
+        default: mypy
+        required: false
+        type: string
 
 jobs:
   mypy:
@@ -20,7 +26,7 @@ jobs:
           cache: "pip"
 
       - name: Install
-        run: pip install mypy pydantic lsst-versions
+        run: pip install '${{ inputs.mypy_package }}' pydantic lsst-versions
 
       - name: Install types dependencies
         run: |


### PR DESCRIPTION
Add an input to the mypy workflow 'mypy_package' so that users can specify a version for the mypy package used for running typechecks.