### PR TITLE
DM-45748-hotfix: Add Missing Workflow_call Trigger

### DIFF
--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,10 +1,7 @@
 name: Lint Markdown Files
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,8 +1,7 @@
 name: shellcheck
 
 on:
-  - push
-  - pull_request
+  workflow_call:
 
 jobs:
   shellcheck:


### PR DESCRIPTION
Both markdownlint.yaml and spellcheck were missing the correct trigger. This hotfix adds it.